### PR TITLE
Cleanup non-standard version numbers

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set default_version = '0.14.5' %}
 
   {% set raw_version = environ.get('GIT_DESCRIBE_TAG', default_version) %}
-  {% set sanitized_version = raw_version | regex_replace('[^0-9.]', '') | regex_replace('^v', '') %}
+  {% set sanitized_version = raw_version | replace('[^0-9.]', '') | replace('^v', '') %}
 
 package:
   name: imp.bff


### PR DESCRIPTION
Fix Jinja2 doesn't have a built-in
regex_replace filter.Use replace filter
with a regular expression.